### PR TITLE
Feature/modify s3 upload path

### DIFF
--- a/lib/tasks/fix.rake
+++ b/lib/tasks/fix.rake
@@ -95,7 +95,7 @@ namespace :fix do
         file_name = path_parts[-1]
         puts "...uploading #{s3_key}"
 
-        obj = aws_s3_bucket.objects[File.join(s3_key, file_name)]
+        obj = aws_s3_bucket.objects[s3_key]
         obj.write(file: path_name)
       end
     end

--- a/lib/tasks/fix.rake
+++ b/lib/tasks/fix.rake
@@ -90,7 +90,7 @@ namespace :fix do
       source_dir = File.join(SAMPLE_DIR, S3_OUTPUT_DIR)
 
       recurse_fs_files(source_dir) do |path_name|
-        path_parts = /^#{Regexp.escape(source_dir)}(.+)/.match(path_name)[1].split('/')
+        path_parts = /^#{Regexp.escape(source_dir)}(.+)/.match(path_name)[1].split('/').reject(&:empty?)
         s3_key = File.join(aws_s3_path, *path_parts)
         file_name = path_parts[-1]
         puts "...uploading #{s3_key}"


### PR DESCRIPTION
`rake fix:import:s3` を実行して登録される画像がアプリから参照できなくなる対策。

参照できない理由は下記の2つだった。
1. S3にアップロードされるオブジェクトのKEYに空白ディレクトリが含まれていた。(アプリから参照するURLに空白ディレクトリは存在しない)
2. S3にアップロードされるオブジェクトのKEY末尾が _画像ファイル名/画像ファイル名_ のようになっていた。(アプリから参照するURLでは 画像ファイル名 で終了)

それぞれのコミットで1つずつ訂正しています。
